### PR TITLE
[WIP] Feature/subscriptions

### DIFF
--- a/channels/channels.go
+++ b/channels/channels.go
@@ -3,74 +3,18 @@ package channels
 import (
 	"appengine"
 	"appengine/channel"
-	"appengine/datastore"
+	"code.google.com/p/go-uuid/uuid"
 	"log"
-	"net/http"
-	"strconv"
 )
 
-type Channel struct {
-	Location       appengine.GeoPoint
-	SubscriptionID int
+func OpenChannel(context appengine.Context) (string, string, error) {
+	channelId := uuid.New()
+	log.Printf("creating new channel with id %s", channelId)
+	token, err := channel.Create(context, channelId)
+	return token, channelId, err
 }
 
-func OpenNewChannel(request *http.Request) (string, string, error) {
-	newChannel := ParseRequestToChannel(request)
-	context := appengine.NewContext(request)
-	tempKey := datastore.NewIncompleteKey(context, "Channel", nil)
-	savedKey, err := datastore.Put(context, tempKey, newChannel)
-	if err != nil {
-		return "", "", err
-	}
-	savedKeyString := strconv.FormatInt(savedKey.IntID(), 10)
-	log.Print(savedKeyString)
-	token, err := channel.Create(context, savedKeyString)
-	StartChannelRefreshTask(savedKeyString)
-	return token, savedKeyString, err
-}
-
-func SendToChannel(channelIdentifier string, request *http.Request) error {
-	context := appengine.NewContext(request)
-	err := channel.SendJSON(context, channelIdentifier, []string{"Stuff", "Things"})
+func SendToChannel(context appengine.Context, channelId string) error {
+	err := channel.SendJSON(context, channelId, []string{"Stuff", "Things"})
 	return err
-}
-
-func ParseRequestToChannel(request *http.Request) *Channel {
-	lat, _ := strconv.ParseFloat(request.FormValue("lat"), 32)
-	lng, _ := strconv.ParseFloat(request.FormValue("lng"), 32)
-
-	location := appengine.GeoPoint{
-		Lat: lat,
-		Lng: lng,
-	}
-	channel := &Channel{
-		Location: location,
-	}
-	return channel
-}
-
-func AddSubscriptionIDToChannel(channelIdentifier string, request *http.Request) {
-	context := appengine.NewContext(request)
-	channelId, err := strconv.ParseInt(channelIdentifier, 10, 32)
-	if err != nil {
-		return
-	}
-	existingKey := datastore.NewKey(context, "Channel", "", channelId, nil)
-	var channel Channel
-	err = datastore.Get(context, existingKey, &channel)
-	if err != nil {
-		return
-	}
-}
-
-func LoadChannelFromSubscriptionID(subscriptionId int, request *http.Request) (Channel, error) {
-	context := appengine.NewContext(request)
-	query := datastore.NewQuery("Channel").Filter("SubscriptionID = ", subscriptionId)
-	var channels []Channel
-	_, err := query.GetAll(context, &channels)
-	return channels[0], err
-}
-
-func StartChannelRefreshTask(channelId string) {
-
 }

--- a/subscription/models.go
+++ b/subscription/models.go
@@ -1,0 +1,39 @@
+package subscription
+
+import (
+	"appengine"
+	"appengine/datastore"
+)
+
+type Subscription struct {
+	Type      string
+	Object    string
+	ObjectId  string
+	Aspect    string
+	ChannelId string
+}
+
+func GetSubscriptionById(context appengine.Context, subscriptionId string) (*Subscription, error) {
+	subscriptionKey := datastore.NewKey(context, "Subscription", subscriptionId, 0, nil)
+
+	var subscription Subscription
+	err := datastore.Get(context, subscriptionKey, &subscription)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &subscription, err
+}
+
+func CreateSubscriptionFromConfirmation(context appengine.Context, confirmation *InstagramSubscriptionConfirmation, channelId string) (*datastore.Key, error) {
+	subscriptionKey := datastore.NewKey(context, "Subscription", confirmation.Id, 0, nil)
+	subscription := &Subscription{
+		Type:      confirmation.Type,
+		Object:    confirmation.Object,
+		ObjectId:  confirmation.ObjectId,
+		Aspect:    confirmation.Aspect,
+		ChannelId: channelId,
+	}
+	return datastore.Put(context, subscriptionKey, subscription)
+}

--- a/subscription/tasks.go
+++ b/subscription/tasks.go
@@ -3,9 +3,39 @@ package subscription
 import (
 	"appengine"
 	"appengine/delay"
+	"appengine/urlfetch"
+	"fmt"
+	"io/ioutil"
 	"log"
+	"net/url"
 )
 
-var Subscribe = delay.Func("subscribe", func(c appengine.Context, channelId int, coords string) {
-	log.Printf("establishing subscription for channel=%d and coords=%s", channelId, coords)
+const instagramSubscriptionsURL string = "https://api.instagram.com/v1/subscriptions/"
+const instagramClientId string = "f0a3b8daa2944138816c1ed7cd91f666"
+const instagramClientSecret string = "1e7869e58ae6463fbb6468eb6b9a7490"
+const ngrokProxyURL string = "http://6173d145.ngrok.com"
+
+var Subscribe = delay.Func("subscribe", func(c appengine.Context, channelId int, lat float64, lng float64) {
+	params := url.Values{
+		"client_id":     {instagramClientId},
+		"client_secret": {instagramClientSecret},
+		"object":        {"geography"},
+		"aspect":        {"media"},
+		"lat":           {fmt.Sprintf("%f", lat)},
+		"lng":           {fmt.Sprintf("%f", lng)},
+		"radius":        {"5000"},
+		"callback_url":  {fmt.Sprintf("%s/webhook/", ngrokProxyURL)},
+	}
+
+	client := urlfetch.Client(c)
+	resp, err := client.PostForm(instagramSubscriptionsURL, params)
+
+	if err != nil {
+		log.Println("subscription setup failed with error", err)
+		return
+	}
+
+	defer resp.Body.Close()
+	body, _ := ioutil.ReadAll(resp.Body)
+	log.Printf("%s - %s", resp.Status, body)
 })

--- a/subscription/tasks.go
+++ b/subscription/tasks.go
@@ -4,18 +4,32 @@ import (
 	"appengine"
 	"appengine/delay"
 	"appengine/urlfetch"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
+	"net/http"
 	"net/url"
 )
 
 const instagramSubscriptionsURL string = "https://api.instagram.com/v1/subscriptions/"
 const instagramClientId string = "f0a3b8daa2944138816c1ed7cd91f666"
 const instagramClientSecret string = "1e7869e58ae6463fbb6468eb6b9a7490"
-const ngrokProxyURL string = "http://6173d145.ngrok.com"
 
-var Subscribe = delay.Func("subscribe", func(c appengine.Context, channelId int, lat string, lng string) {
+type InstagramSubscriptionConfirmationMessage struct {
+	Data InstagramSubscriptionConfirmation `json:"data"`
+}
+
+type InstagramSubscriptionConfirmation struct {
+	Id          string `json:"id"`
+	Type        string `json:"type"`
+	Object      string `json:"object"`
+	ObjectId    string `json:"object_id"`
+	Aspect      string `json:"aspect"`
+	CallbackUrl string `json:"callback_url"`
+}
+
+var Subscribe = delay.Func("subscribe", func(context appengine.Context, hostname string, channelId string, lat string, lng string) {
 	params := url.Values{
 		"client_id":     {instagramClientId},
 		"client_secret": {instagramClientSecret},
@@ -24,18 +38,36 @@ var Subscribe = delay.Func("subscribe", func(c appengine.Context, channelId int,
 		"lat":           {lat},
 		"lng":           {lng},
 		"radius":        {"5000"},
-		"callback_url":  {fmt.Sprintf("%s/webhook/", ngrokProxyURL)},
+		"callback_url":  {fmt.Sprintf("http://%s/webhook", hostname)},
 	}
 
-	client := urlfetch.Client(c)
-	resp, err := client.PostForm(instagramSubscriptionsURL, params)
+	client := urlfetch.Client(context)
+	resp, requestErr := client.PostForm(instagramSubscriptionsURL, params)
 
-	if err != nil {
-		log.Println("subscription setup failed with error", err)
+	if requestErr != nil {
+		log.Println("subscription setup failed with error", requestErr)
 		return
 	}
 
 	defer resp.Body.Close()
 	body, _ := ioutil.ReadAll(resp.Body)
-	log.Printf("%s - %s", resp.Status, body)
+
+	if resp.StatusCode != http.StatusOK {
+		log.Printf("subscription request returned non-200 response, %d - %s", resp.StatusCode, body)
+		return
+	}
+
+	var message InstagramSubscriptionConfirmationMessage
+	responseErr := json.Unmarshal(body, &message)
+
+	if responseErr != nil {
+		log.Println("json unmarshalling failed with error", responseErr)
+		log.Println(string(body))
+		return
+	}
+
+	confirmation := message.Data
+	CreateSubscriptionFromConfirmation(context, &confirmation, channelId)
+
+	// NOTE: maybe send "subscription_created" message to client channel?
 })

--- a/subscription/tasks.go
+++ b/subscription/tasks.go
@@ -15,14 +15,14 @@ const instagramClientId string = "f0a3b8daa2944138816c1ed7cd91f666"
 const instagramClientSecret string = "1e7869e58ae6463fbb6468eb6b9a7490"
 const ngrokProxyURL string = "http://6173d145.ngrok.com"
 
-var Subscribe = delay.Func("subscribe", func(c appengine.Context, channelId int, lat float64, lng float64) {
+var Subscribe = delay.Func("subscribe", func(c appengine.Context, channelId int, lat string, lng string) {
 	params := url.Values{
 		"client_id":     {instagramClientId},
 		"client_secret": {instagramClientSecret},
 		"object":        {"geography"},
 		"aspect":        {"media"},
-		"lat":           {fmt.Sprintf("%f", lat)},
-		"lng":           {fmt.Sprintf("%f", lng)},
+		"lat":           {lat},
+		"lng":           {lng},
 		"radius":        {"5000"},
 		"callback_url":  {fmt.Sprintf("%s/webhook/", ngrokProxyURL)},
 	}

--- a/subscription/tasks.go
+++ b/subscription/tasks.go
@@ -1,0 +1,11 @@
+package subscription
+
+import (
+	"appengine"
+	"appengine/delay"
+	"log"
+)
+
+var Subscribe = delay.Func("subscribe", func(c appengine.Context, channelId int, coords string) {
+	log.Printf("establishing subscription for channel=%d and coords=%s", channelId, coords)
+})

--- a/subscription/webhooks.go
+++ b/subscription/webhooks.go
@@ -1,0 +1,44 @@
+package subscription
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+)
+
+type InstagramSubscriptionUpdate struct {
+	SubscriptionId int    `json:"subscription_id"`
+	Object         string `json:"object"`
+	ObjectId       string `json:"object_id"`
+	ChangedAspect  string `json:"changed_aspect"`
+	Time           int    `json:"time"`
+}
+
+func InstagramWebhook(w http.ResponseWriter, r *http.Request) {
+
+	if r.Method == "GET" {
+		log.Println("received instagram subscription challenge")
+		fmt.Fprint(w, r.FormValue("hub.challenge"))
+		return
+	}
+
+	if r.Method == "POST" {
+		log.Println("received instagram subscription update")
+
+		defer r.Body.Close()
+		body, _ := ioutil.ReadAll(r.Body)
+
+		message := make([]InstagramSubscriptionUpdate, 0)
+		err := json.Unmarshal(body, &message)
+
+		if err != nil {
+			log.Println("json unmarshalling failed with error", err)
+			log.Println(string(body))
+		} else {
+			log.Println("message:", message)
+		}
+	}
+
+}

--- a/subscription/webhooks.go
+++ b/subscription/webhooks.go
@@ -16,7 +16,7 @@ type InstagramSubscriptionUpdate struct {
 	Time           int    `json:"time"`
 }
 
-func InstagramWebhook(w http.ResponseWriter, r *http.Request) {
+func InstagramWebhookHandler(w http.ResponseWriter, r *http.Request) {
 
 	if r.Method == "GET" {
 		log.Println("received instagram subscription challenge")
@@ -40,5 +40,4 @@ func InstagramWebhook(w http.ResponseWriter, r *http.Request) {
 			log.Println("message:", message)
 		}
 	}
-
 }

--- a/web/templates/search.html
+++ b/web/templates/search.html
@@ -1,5 +1,5 @@
 <h1>Search</h1>
-<form method="post" action="/results">
+<form method="get" action="/results">
     <input type="hidden" name="lat" value="40.758883" />
     <input type="hidden" name="lng" value="-73.985132" />
     <input type="submit" value="Search" />


### PR DESCRIPTION
This PR implements the subscription flow from channel open up to the point when we start getting subscription update messages from the Instagram API. These JSON messages are just unmarshalled and logged for now. Subscription information is stored in the datastore along with the ID of the channel which we've opened to the connected client. This will allow us to easily retrieve the channel ID and post messages to the correct channel when we start to properly handle the updates from Instagram.
